### PR TITLE
add hook to access terraform state prior to disk write

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ".json"
+exclude: ".(json|md)"
 repos:
   - repo: https://github.com/psf/black
     rev: 19.10b0
@@ -14,7 +14,6 @@ repos:
     rev: 4.3.21-2
     hooks:
       - id: isort
-        additional_dependencies: [pyproject]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0

--- a/README.md
+++ b/README.md
@@ -119,6 +119,37 @@ This should generally only be used in very specific situations and is considered
 
 There is a special `pytest_terraform.teardown.DEFAULT` which is what the `teardown` parameter actually defaults to.
 
+## Hooks
+
+pytest_terraform provides hooks via the pytest hook implementation.
+Hooks should be added in the `conftest.py` file.
+
+### `pytest_terraform_modify_state`
+
+This hook is executed after state has been captured from terraform apply and before writing the `tf_resources.json` file.
+The state is passed as the kwarg `tfstate` which is a `TerraformStateJson` UserString class with the following methods and properties:
+
+- `TerraformStateJson.dict` - The deserialized state as a dict
+- `TerraformStateJson.update(state: str)` - Replace the serialized state with a new state string
+- `TerraformStateJson.update_dict(state: dict)` - Replace the serialized state from a dictionary
+
+#### Example
+
+```python
+def pytest_terraform_modify_state(tfstate):
+    print(str(tfstate))
+```
+
+#### Example AWS Account scrub
+
+```python
+import re
+
+def pytest_terraform_modify_state(tfstate):
+    """ Replace potential AWS account numbers with 'REDACTED' """
+    tfstate.update(re.sub(r'([0-9]+){12}', 'REDACTED', str(tfstate)))
+```
+
 ## Flight Recording
 
 The usage/philosophy of this plugin is based on using flight recording

--- a/poetry.lock
+++ b/poetry.lock
@@ -657,7 +657,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ff65bd4ff214c6a595f804904a09b7c0aa5cf098157b07bbc0d626373b4277a7"
+content-hash = "710b36d09cc789f523d3342277847ded1047a591c9686bd6ee80eb5dacf98fdc"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ lines_between_types = 1
 multi_line_output = 3
 use_parentheses = true
 not_skip = "__init__.py"
-skip_glob = ["*/setup.py", "*tf"]
+skip_glob = ["*/setup.py", "*tf", "*md"]
 filter_files = true
 
 known_first_party = "poetry"

--- a/pytest_terraform/hooks.py
+++ b/pytest_terraform/hooks.py
@@ -1,0 +1,2 @@
+def pytest_terraform_modify_state(tfstate):
+    """ called before tfstate is saved to disk """

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -16,7 +16,7 @@ import os
 from collections import defaultdict
 
 import pytest
-from pytest_terraform import tf, xdist
+from pytest_terraform import hooks, tf, xdist
 
 
 @pytest.hookimpl(trylast=True)
@@ -39,12 +39,19 @@ def pytest_configure(config):
             "specified with --tf-binary"
         )
 
+    tf.PytestConfig.value = config
+
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(xdist.XDistTerraform(config))
         tf.terraform.scope_class_map = d = defaultdict(
             lambda: xdist.ScopedTerraformFixture
         )
         d["function"] = tf.TerraformFixture
+
+
+def pytest_addhooks(pluginmanager):
+    """ Register pytest_terraform hooks """
+    pluginmanager.add_hookspecs(hooks)
 
 
 def pytest_addoption(parser):

--- a/tests/data/mrofarret/local_baz/tf_resources.json
+++ b/tests/data/mrofarret/local_baz/tf_resources.json
@@ -1,1 +1,17 @@
-{"pytest-terraform": 1, "outputs": {}, "resources": {"local_file": {"baz": {"content": "baz!", "content_base64": null, "directory_permission": "0777", "file_permission": "0777", "filename": "./baz.txt", "id": "5fc5caaa8d04abb85be16b17953cd1a6e3ed549b", "sensitive_content": null}}}}
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "local_file": {
+            "baz": {
+                "content": "baz!",
+                "content_base64": null,
+                "directory_permission": "0777",
+                "file_permission": "0777",
+                "filename": "./baz.txt",
+                "id": "5fc5caaa8d04abb85be16b17953cd1a6e3ed549b",
+                "sensitive_content": null
+            }
+        }
+    }
+}

--- a/tests/terraform/local_bar/tf_resources.json
+++ b/tests/terraform/local_bar/tf_resources.json
@@ -1,1 +1,17 @@
-{"pytest-terraform": 1, "outputs": {}, "resources": {"local_file": {"bar": {"content": "bar!", "content_base64": null, "directory_permission": "0777", "file_permission": "0777", "filename": "./bar.txt", "id": "3811e1a645e5371113584e6d18ff4843378ae590", "sensitive_content": null}}}}
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "local_file": {
+            "bar": {
+                "content": "bar!",
+                "content_base64": null,
+                "directory_permission": "0777",
+                "file_permission": "0777",
+                "filename": "./bar.txt",
+                "id": "3811e1a645e5371113584e6d18ff4843378ae590",
+                "sensitive_content": null
+            }
+        }
+    }
+}

--- a/tests/terraform/local_foo/tf_resources.json
+++ b/tests/terraform/local_foo/tf_resources.json
@@ -1,1 +1,17 @@
-{"pytest-terraform": 1, "outputs": {}, "resources": {"local_file": {"foo": {"content": "foo!", "content_base64": null, "directory_permission": "0777", "file_permission": "0777", "filename": "./foo.txt", "id": "4bf3e335199107182c6f7638efaad377acc7f452", "sensitive_content": null}}}}
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "local_file": {
+            "foo": {
+                "content": "foo!",
+                "content_base64": null,
+                "directory_permission": "0777",
+                "file_permission": "0777",
+                "filename": "./foo.txt",
+                "id": "4bf3e335199107182c6f7638efaad377acc7f452",
+                "sensitive_content": null
+            }
+        }
+    }
+}

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -57,6 +57,20 @@ def test_tf_resources():
     assert str(excinfo.value).splitlines()[0] == "Ambigious resource name rest_api"
 
 
+def test_tf_string_resources():
+    with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
+        burnify = f.read()
+
+    state = tf.TerraformState.load(burnify)
+    save_state = state.save()
+    reload = tf.TerraformState.load(save_state)
+
+    assert len(state.resources) == 9
+    assert len(reload.resources) == 9
+
+    assert save_state == reload.save()
+
+
 @pytest.mark.skipif(not tf.find_binary("terraform"), reason="Terraform binary missing")
 def test_tf_runner(testdir, tmpdir):
     # ** requires network access to install plugin **

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import os
 from pathlib import Path
 
@@ -62,6 +63,20 @@ def test_tf_string_resources():
         burnify = f.read()
 
     state = tf.TerraformState.load(burnify)
+    save_state = str(state.save())
+    reload = tf.TerraformState.load(save_state)
+
+    assert len(state.resources) == 9
+    assert len(reload.resources) == 9
+
+    assert save_state == reload.save()
+
+
+def test_tf_statejson_resources():
+    with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
+        burnify = f.read()
+
+    state = tf.TerraformState.load(burnify)
     save_state = state.save()
     reload = tf.TerraformState.load(save_state)
 
@@ -69,6 +84,61 @@ def test_tf_string_resources():
     assert len(reload.resources) == 9
 
     assert save_state == reload.save()
+
+
+def test_tf_statejson_from_dict():
+    obj = {
+        "test": "foo",
+        "nested": {"bar": "baz"},
+    }
+
+    statejson = tf.TerraformStateJson.from_dict(obj)
+    assert str(statejson) == json.dumps(obj, indent=4)
+    assert statejson.dict == obj
+
+
+def test_tf_statejson_bad_dict():
+    obj = {
+        "test": "foo",
+        "nested": {"bar": "baz"},
+        "embed": tf.PlaceHolderValue("test"),
+    }
+
+    statejson = tf.TerraformStateJson("")
+    with pytest.raises(ValueError):
+        statejson.dict = obj
+
+
+def test_tf_statejson_update():
+    newobj = {
+        "differet": True,
+    }
+
+    newstr = json.dumps(newobj)
+
+    statejson = tf.TerraformStateJson("")
+    statejson.update(newstr)
+
+    assert str(statejson) == newstr
+
+
+def test_tf_statejson_update_dict():
+    newobj = {
+        "differet": True,
+    }
+
+    statejson = tf.TerraformStateJson("")
+    statejson.update_dict(newobj)
+
+    assert statejson.dict == newobj
+
+
+def test_tf_statejson_update_bad():
+
+    statejson = tf.TerraformStateJson("hello")
+
+    with pytest.raises(ValueError):
+        statejson.update({"hello": "world"})
 
 
 @pytest.mark.skipif(not tf.find_binary("terraform"), reason="Terraform binary missing")

--- a/tests/test_tf_fixture.py
+++ b/tests/test_tf_fixture.py
@@ -48,6 +48,7 @@ def test_tf_teardown_register():
         test_dir="fakedir",
         replay=False,
         teardown=tf.td.ON,
+        pytest_config=MagicMock(),
     )
 
     fixture.runner = MagicMock()
@@ -69,6 +70,7 @@ def test_tf_teardown_exception():
         test_dir="fakedir",
         replay=False,
         teardown=tf.td.ON,
+        pytest_config=MagicMock(),
     )
 
     request = MagicMock()
@@ -89,6 +91,7 @@ def test_tf_teardown_register_ignore():
         test_dir="fakedir",
         replay=False,
         teardown=tf.td.IGNORE,
+        pytest_config=MagicMock(),
     )
 
     request = MagicMock()
@@ -110,6 +113,7 @@ def test_tf_skip_teardown_register():
         test_dir="fakedir",
         replay=False,
         teardown=tf.td.OFF,
+        pytest_config=MagicMock(),
     )
 
     fixture.runner = MagicMock()
@@ -118,6 +122,27 @@ def test_tf_skip_teardown_register():
     fixture.create(request, MagicMock())
 
     request.addfinalizer.assert_not_called()
+
+
+def test_tf_hook_modify_state():
+    pytest_config = MagicMock()
+    fixture = tf.TerraformFixture(
+        tf_bin="fakebin",
+        plugin_cache="fakecache",
+        scope="function",
+        tf_root_module="fakeroot",
+        test_dir="fakedir",
+        replay=False,
+        teardown=tf.td.DEFAULT,
+        pytest_config=pytest_config,
+    )
+
+    fixture.runner = MagicMock()
+    fixture.create(MagicMock(), MagicMock())
+
+    test_api = fixture.runner.apply.return_value
+    hook = pytest_config.hook.pytest_terraform_modify_state
+    hook.assert_called_with(tfstate=test_api)
 
 
 @patch.object(tf.TerraformFixture, "__call__")

--- a/tests/test_tf_fixture.py
+++ b/tests/test_tf_fixture.py
@@ -140,9 +140,9 @@ def test_tf_hook_modify_state():
     fixture.runner = MagicMock()
     fixture.create(MagicMock(), MagicMock())
 
-    test_api = fixture.runner.apply.return_value
+    tfstate_json = fixture.runner.apply.return_value.save.return_value
     hook = pytest_config.hook.pytest_terraform_modify_state
-    hook.assert_called_with(tfstate=test_api)
+    hook.assert_called_with(tfstate=tfstate_json)
 
 
 @patch.object(tf.TerraformFixture, "__call__")


### PR DESCRIPTION
I couldn't think of a good name for this hook definitely open to suggestions. I added the hook right after the apply but before the `save` method is invoked. Since we're wholesale sending the TerraformState (via the TerraformTestApi) this means someone could invoke the `save` method in their hook. Shouldn't cause any harm but it won't disrupt the subsequent save from happening. Alternatively, if we wanted to avoid passing the entire TerraformState object to the user / plugin we could extract just the two keys as a dict then re-add them to the state.

Example usage

```python
import re

def pytest_terraform_modify_state(tfstate):
    state = tfstate.save()
    state = re.sub(r'([0-9]+){12}', '644160558196', state)
    tfstate.load(state)
```