### PR TITLE
make TerraformState classmethods more clear

### DIFF
--- a/pytest_terraform/exceptions.py
+++ b/pytest_terraform/exceptions.py
@@ -12,3 +12,11 @@ class InvalidOption(PytestTerraformError):
 
 class InvalidTeardownMode(InvalidOption):
     """Invalid Teardown Option Error"""
+
+
+class InvalidState(PytestTerraformError):
+    """Failure to load / parse state"""
+
+
+class ModuleNotFound(ValueError):
+    """module not found"""

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -205,7 +205,7 @@ class TerraformState(object):
         resources, outputs = cls.parse_state(state)
         return cls(resources, outputs)
 
-    def load(self, state):
+    def update(self, state):
         resources, outputs = self.parse_state(state)
         self.resources = resources
         self.outputs = outputs
@@ -362,7 +362,7 @@ class TerraformFixture(object):
             test_api = self.runner.apply()
             tfstatejson = test_api.save()
             self.config.hook.pytest_terraform_modify_state(tfstate=tfstatejson)
-            test_api.load(tfstatejson)
+            test_api.update(tfstatejson)
             test_api.save(module_dir.join("tf_resources.json"))
             return test_api
         except Exception:

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -63,9 +63,9 @@ def test_tf_string_resources():
     with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
         burnify = f.read()
 
-    state = tf.TerraformState.from_state(burnify)
+    state = tf.TerraformState.from_string(burnify)
     save_state = str(state.save())
-    reload = tf.TerraformState.from_state(save_state)
+    reload = tf.TerraformState.from_string(save_state)
 
     assert len(state.resources) == 9
     assert len(reload.resources) == 9
@@ -77,9 +77,9 @@ def test_tf_statejson_resources():
     with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
         burnify = f.read()
 
-    state = tf.TerraformState.from_state(burnify)
+    state = tf.TerraformState.from_string(burnify)
     save_state = state.save()
-    reload = tf.TerraformState.from_state(save_state)
+    reload = tf.TerraformState.from_string(save_state)
 
     assert len(state.resources) == 9
     assert len(reload.resources) == 9

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from pytest_terraform import tf
+from pytest_terraform.exceptions import InvalidState
 
 
 def test_frame_walk():
@@ -42,7 +43,7 @@ def test_fixture_factory():
 
 
 def test_tf_resources():
-    state = tf.TerraformState.load(
+    state = tf.TerraformState.from_file(
         os.path.join(os.path.dirname(__file__), "burnify.tfstate")
     )
 
@@ -62,9 +63,9 @@ def test_tf_string_resources():
     with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
         burnify = f.read()
 
-    state = tf.TerraformState.load(burnify)
+    state = tf.TerraformState.from_state(burnify)
     save_state = str(state.save())
-    reload = tf.TerraformState.load(save_state)
+    reload = tf.TerraformState.from_state(save_state)
 
     assert len(state.resources) == 9
     assert len(reload.resources) == 9
@@ -76,14 +77,19 @@ def test_tf_statejson_resources():
     with open(os.path.join(os.path.dirname(__file__), "burnify.tfstate")) as f:
         burnify = f.read()
 
-    state = tf.TerraformState.load(burnify)
+    state = tf.TerraformState.from_state(burnify)
     save_state = state.save()
-    reload = tf.TerraformState.load(save_state)
+    reload = tf.TerraformState.from_state(save_state)
 
     assert len(state.resources) == 9
     assert len(reload.resources) == 9
 
     assert save_state == reload.save()
+
+
+def test_tf_state_bad_file():
+    with pytest.raises(InvalidState):
+        tf.TerraformState.from_file("/not-exists1")
 
 
 def test_tf_statejson_from_dict():


### PR DESCRIPTION
This PR came about because in a previous update I abused the `load` classmethod as a way to update `TerraformState` after the `modify_state` hook runs. Since it's a classmethod it spawns a new class object instead of loading over it's existing state. This introduces `TerraformState.from_file` and `TerraformState.from_state` classmethods which expand on what the `load` classmethod was doing previously. `load` now updates the existing invocation and the state parsing code has been moved to a static method.

The two reservations I have and am looking to get explicit feedback on is:

1. Should `load` be renamed to `update` in order to better highlight it's purpse?
2. Should `from_state` be renamed to something like `from_str` given the data passed to it is likely a string representation of state?