### PR TITLE
fix dep spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.3.0"
+version = "0.3.1"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ classifiers=[
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = ">= 3.6"
 pytest = ">= 5.3.5"
 jmespath = "^0.10.0"
 portalocker = "^1.7.0"


### PR DESCRIPTION
aligning dep spec with that of the rest custodian packages wrt to base python, poetry has some issues on the simple things sometimes.