### PR TITLE
redo dep spec again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.3.1"
+version = "0.3.2"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ classifiers=[
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">= 3.6"
+python = "^3.6"
 pytest = ">= 5.3.5"
 jmespath = "^0.10.0"
 portalocker = "^1.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pytest = ">= 5.3.5"
+pytest = "~6.0.0"
 jmespath = "^0.10.0"
 portalocker = "^1.7.0"
 


### PR DESCRIPTION
followup from #21 greater than 3.6 doesn't work as other ecosys packages pin under <4 as well