### PR TITLE
feature - add teardown options to terraform fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ This should generally only be used in very specific situations and is considered
 
 There is a special `pytest_terraform.teardown.DEFAULT` which is what the `teardown` parameter actually defaults to.
 
+Teardown options are available, for convenience, on the terraform decorator.
+For example, set teardown to ignore:
+
+```python
+from pytest_terraform import terraform
+
+
+@terraform('aws_sqs', teardown=terraform.TEARDOWN_IGNORE)
+def test_sqs(aws_sqs):
+    assert aws_sqs["aws_sqs_queue.test_queue.tags"] == {
+        "Environment": "production"
+    }
+   queue_url = aws_sqs['test_queue.queue_url']
+   print(queue_url)
+```
+
 ## Hooks
 
 pytest_terraform provides hooks via the pytest hook implementation.

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -412,6 +412,11 @@ class FixtureDecoratorFactory(object):
 
     scope_class_map = defaultdict(lambda: TerraformFixture)
 
+    # Make accessing teardown options easier for users
+    TEARDOWN_IGNORE = td.IGNORE
+    TEARDOWN_OFF = td.OFF
+    TEARDOWN_ON = td.ON
+
     def __init__(self):
         self._fixtures = []
 


### PR DESCRIPTION
There's two ways I see to approach this. The first is what's in this PR where `TEARDOWN_*` is mapped to the right teardown value. The second is to just have a `teardown` member on the class that's set to `pytest_terraform.options.teardown`. That would yield:

```python
from pytest_terraform import terraform


@terraform('aws_sqs', teardown=terraform.teardown.IGNORE)
def test_sqs(aws_sqs):
    assert aws_sqs["aws_sqs_queue.test_queue.tags"] == {
        "Environment": "production"
    }
   queue_url = aws_sqs['test_queue.queue_url']
   print(queue_url)
```

Open to either approach, or even something different, to make developer experience a little cleaner