### PR TITLE
bug - modify_state hook should operate on a copy of state

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ Hooks should be added in the `conftest.py` file.
 
 ### `pytest_terraform_modify_state`
 
-This hook is executed after state has been captured from terraform apply and before writing the `tf_resources.json` file.
+This hook is executed after state has been captured from terraform apply and before writing to disk.
+This hook does not modify state that's passed to the function under test.
 The state is passed as the kwarg `tfstate` which is a `TerraformStateJson` UserString class with the following methods and properties:
 
 - `TerraformStateJson.dict` - The deserialized state as a dict

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -268,16 +268,21 @@ class TerraformState(object):
 
         return (resources, outputs)
 
-    def save(self, state_path: Optional[str] = None) -> Optional[TerraformStateJson]:
-        """export state as a string or to a file"""
+    def export(self):
+        """export state as a TerraformStateJson UserString"""
+
         state = {
             "pytest-terraform": 1,
             "outputs": self.outputs,
             "resources": self.resources,
         }
 
-        output = TerraformStateJson.from_dict(state)
+        return TerraformStateJson.from_dict(state)
 
+    def save(self, state_path: Optional[str] = None) -> Optional[TerraformStateJson]:
+        """export state to a file"""
+
+        output = self.export()
         if not state_path:
             return output
 
@@ -387,7 +392,7 @@ class TerraformFixture(object):
             request.addfinalizer(self.tear_down)
         try:
             state = self.runner.apply()
-            statejson = state.save()
+            statejson = state.export()
             test_api = TerraformTestApi.from_string(statejson)
 
             self.config.hook.pytest_terraform_modify_state(tfstate=statejson)

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -392,12 +392,12 @@ class TerraformFixture(object):
             request.addfinalizer(self.tear_down)
         try:
             state = self.runner.apply()
-            statejson = state.export()
-            test_api = TerraformTestApi.from_string(statejson)
+            state_json = state.export()
+            test_api = TerraformTestApi.from_string(state_json)
 
-            self.config.hook.pytest_terraform_modify_state(tfstate=statejson)
+            self.config.hook.pytest_terraform_modify_state(tfstate=state_json)
 
-            state.update(statejson)
+            state.update(state_json)
             state.save(module_dir.join("tf_resources.json"))
 
             return test_api

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -386,11 +386,15 @@ class TerraformFixture(object):
         if self.teardown_config != td.OFF:
             request.addfinalizer(self.tear_down)
         try:
-            test_api = self.runner.apply()
-            tfstatejson = test_api.save()
+            terraform_state = self.runner.apply()
+            tfstatejson = terraform_state.save()
+            test_api = TerraformTestApi.from_string(tfstatejson)
+
             self.config.hook.pytest_terraform_modify_state(tfstate=tfstatejson)
-            test_api.update(tfstatejson)
-            test_api.save(module_dir.join("tf_resources.json"))
+
+            terraform_state.update(tfstatejson)
+            terraform_state.save(module_dir.join("tf_resources.json"))
+
             return test_api
         except Exception:
             raise

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -386,14 +386,14 @@ class TerraformFixture(object):
         if self.teardown_config != td.OFF:
             request.addfinalizer(self.tear_down)
         try:
-            terraform_state = self.runner.apply()
-            tfstatejson = terraform_state.save()
-            test_api = TerraformTestApi.from_string(tfstatejson)
+            state = self.runner.apply()
+            statejson = state.save()
+            test_api = TerraformTestApi.from_string(statejson)
 
-            self.config.hook.pytest_terraform_modify_state(tfstate=tfstatejson)
+            self.config.hook.pytest_terraform_modify_state(tfstate=statejson)
 
-            terraform_state.update(tfstatejson)
-            terraform_state.save(module_dir.join("tf_resources.json"))
+            state.update(statejson)
+            state.save(module_dir.join("tf_resources.json"))
 
             return test_api
         except Exception:

--- a/tests/terraform/local_buz/buz.tf
+++ b/tests/terraform/local_buz/buz.tf
@@ -1,0 +1,4 @@
+resource "local_file" "buz" {
+   content = "buz!"
+   filename = "${path.module}/buz.txt"
+}

--- a/tests/terraform/local_buz/tf_resources.json
+++ b/tests/terraform/local_buz/tf_resources.json
@@ -1,0 +1,17 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "local_file": {
+            "buz": {
+                "content": "fiz!",
+                "content_base64": null,
+                "directory_permission": "0777",
+                "file_permission": "0777",
+                "filename": "./buz.txt",
+                "id": "1eb8252c1ec503dce3b41735251e12bdeadf1493",
+                "sensitive_content": null
+            }
+        }
+    }
+}

--- a/tests/test_tf_fixture.py
+++ b/tests/test_tf_fixture.py
@@ -52,6 +52,7 @@ def test_tf_teardown_register():
     )
 
     fixture.runner = MagicMock()
+    fixture.runner.apply.return_value = tf.TerraformState({}, {})
     request = MagicMock()
 
     fixture.create(request, MagicMock())
@@ -75,6 +76,7 @@ def test_tf_teardown_exception():
 
     request = MagicMock()
     fixture.runner = MagicMock()
+    fixture.runner.apply.return_value = tf.TerraformState({}, {})
     fixture.runner.destroy.side_effect = [subprocess.CalledProcessError(99, "test")]
 
     fixture.create(request, MagicMock())
@@ -96,6 +98,7 @@ def test_tf_teardown_register_ignore():
 
     request = MagicMock()
     fixture.runner = MagicMock()
+    fixture.runner.apply.return_value = tf.TerraformState({}, {})
     fixture.runner.destroy.side_effect = [subprocess.CalledProcessError(99, "test")]
 
     fixture.create(request, MagicMock())
@@ -116,8 +119,9 @@ def test_tf_skip_teardown_register():
         pytest_config=MagicMock(),
     )
 
-    fixture.runner = MagicMock()
     request = MagicMock()
+    fixture.runner = MagicMock()
+    fixture.runner.apply.return_value = tf.TerraformState({}, {})
 
     fixture.create(request, MagicMock())
 
@@ -137,10 +141,12 @@ def test_tf_hook_modify_state():
         pytest_config=pytest_config,
     )
 
+    state = tf.TerraformState({"one": 2}, {"three": 4})
     fixture.runner = MagicMock()
+    fixture.runner.apply.return_value = state
     fixture.create(MagicMock(), MagicMock())
 
-    tfstate_json = fixture.runner.apply.return_value.save.return_value
+    tfstate_json = state.save()
     hook = pytest_config.hook.pytest_terraform_modify_state
     hook.assert_called_with(tfstate=tfstate_json)
 


### PR DESCRIPTION
Two things are addressed in this. The first is what is passed back to the function under test. During replays that's `TerraformTestApi` and during live runs it's `TerraformState` while functionally both the same thing, we want to make sure we don't leak `TerraformState` directly to the function under test as `TerraformTestApi` interface will likely grow in the future.

Second item, if the modify_state hook is implemented in a test run then the modified state is not only written to disk but also returned to the function under test. What should happen is the unmodified state during record / live runs is returned to the function under test and a copy is passed through the modify_state hook before writing to disk.