### PR TITLE
Always use check_call when running a terraform command

### DIFF
--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -109,7 +109,7 @@ class TerraformRunner(object):
             env["TF_DATA_DIR"] = self.work_dir
         cwd = self.module_dir or self.work_dir
         print("run cmd", args, file=sys.stderr)
-        run_cmd = self.debug and subprocess.check_call or subprocess.check_output
+        run_cmd = subprocess.check_call
         run_cmd(args, cwd=cwd, stderr=subprocess.STDOUT, env=env)
 
 


### PR DESCRIPTION
Forgive the scrappy PR, but I was surprised to see that the default here is to suppress stderr output in case executing a terraform command fails. So I would only get the message "returned nonzero exit code" or some such, rather than being able to read what actually went wrong, i.e. the stderr output. Is there any case where you would *not* want this output? I'd argue that for a testing tool, the reasonable default is to be verbose in case of error.