### PR TITLE
feat: expose working dir off test resources api when running live

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.5.3"
+version = "0.6.0"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -24,9 +24,10 @@ from pytest_terraform import hooks, tf, xdist
 def pytest_configure(config):
     config.addinivalue_line("markers", "terraform: tests using terraform fixtures")
 
-    tf.LazyPluginCacheDir.value = cache_dir = config.getoption("dest_tf_plugin")
+    cache_dir = config.getoption("dest_tf_plugin")
     if not os.path.exists(cache_dir):
         os.mkdir(cache_dir)
+    tf.LazyPluginCacheDir.value = os.path.abspath(cache_dir)
 
     tf.LazyModuleDir.value = config.getoption("dest_tf_mod_dir") or config.getini(
         "terraform-mod-dir"

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -72,7 +72,7 @@ class TerraformRunner(object):
         elif plan:
             apply_args = self._get_cmd_args("apply", plan="")
         self._run_cmd(apply_args)
-        return TerraformState.from_file(self.state_path)
+        return TerraformState.from_file(self.state_path, self)
 
     def plan(self, output=""):
         output = output and "-out=%s" % output or ""
@@ -195,7 +195,7 @@ class TerraformState(object):
         return default
 
     @classmethod
-    def from_file(cls, path: str):
+    def from_file(cls, path: str, runner=None):
         """create TerraformState from a file
 
         File can either be a Terraform Plan state, or a recorded
@@ -207,7 +207,7 @@ class TerraformState(object):
         with open(path) as fh:
             state = fh.read()
 
-        return cls.from_string(state)
+        return cls.from_string(state, runner)
 
     @classmethod
     def from_string(cls, state: Union[TerraformStateJson, str], runner=None):

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -169,6 +169,7 @@ resource "local_file" "foo" {
         assert fh.read() == "foo!"
 
     assert state.work_dir is not None
+    assert isinstance(state.terraform.show(), dict)
     trunner.destroy()
     assert False is tmpdir.join("foo.bar").exists()
 

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -168,6 +168,7 @@ resource "local_file" "foo" {
     with open(tmpdir.join("foo.bar")) as fh:
         assert fh.read() == "foo!"
 
+    assert state.work_dir is not None
     trunner.destroy()
     assert False is tmpdir.join("foo.bar").exists()
 


### PR DESCRIPTION
some usage of terraform want to know the actual module/work dir location, expose it when we're running terraform (not the replay case) off test resources api.