### PR TITLE
Use the name parameter as the name of the fixture

### DIFF
--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -493,7 +493,7 @@ class FixtureDecoratorFactory(object):
             PytestConfig.resolve(),
         )
         self._fixtures.append(tfix)
-        marker = pytest.fixture(scope=scope, name=terraform_dir)
+        marker = pytest.fixture(scope=scope, name=name)
         f.f_locals[name] = marker(tfix)
         return self.nonce_decorator
 


### PR DESCRIPTION
The fixture name is copied from the tf directory you specify, howerver it's more useful if the fixture name is the actual name you specify