### PR TITLE
releng - release 0.6.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Publish
         if: startsWith(github.ref, 'refs/tags/')
-        run:
+        run: |
           poetry config http-basic.pypi "__token__" "${{ secrets.PYPI_TOKEN }}"
           poetry publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.6.3"
+version = "0.6.4"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.6.2"
+version = "0.6.3"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
0.6.2 got accidentally named 0.6.3 on the tag, but that conflicted with the in source version of 0.6.2, so incrementing forward to 0.6.4. hopefully with all the release  automation in place this will become a thing of the past.

