### PR TITLE
fix,feat: shared plugin cache dir is a no-op, only selected tests are tracked for fixture cleanup, hide debug output behind a flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ dist/
 pytestdebug.log
 .venv
 
-tests/**/.terraform.lock.hcl
+# tests/**/.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
       - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-terraform"
-version = "0.6.5"
+version = "0.6.6"
 description = "A pytest plugin for using terraform fixtures"
 authors = ["Kapil Thangavelu <kapilt@gmail.com>"]
 license = "Apache-2.0"

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -44,8 +44,8 @@ def pytest_configure(config):
         )
 
     tf.PytestConfig.value = config
-    tf.LazyTFDebug.value = config.getoption('dest_tf_debug') or False
-    tf.TerraformRunner.debug = config.getoption('dest_tf_debug') or False
+    tf.LazyTFDebug.value = config.getoption("dest_tf_debug") or False
+    tf.TerraformRunner.debug = config.getoption("dest_tf_debug") or False
 
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(xdist.XDistTerraform(config))
@@ -79,7 +79,7 @@ def pytest_addoption(parser):
         action="store_true",
         dest="dest_tf_debug",
         help=("Debug terraform output and plugin output"),
-    )    
+    )
     group.addoption(
         "--tf-mod-dir",
         action="store",

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import shutil
 from collections import defaultdict
 
@@ -25,9 +24,9 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "terraform: tests using terraform fixtures")
 
     cache_dir = config.getoption("dest_tf_plugin")
-    if not os.path.exists(cache_dir):
-        os.mkdir(cache_dir)
-    tf.LazyPluginCacheDir.value = os.path.abspath(cache_dir)
+
+    if cache_dir:
+        pass
 
     tf.LazyModuleDir.value = config.getoption("dest_tf_mod_dir") or config.getini(
         "terraform-mod-dir"
@@ -92,8 +91,8 @@ def pytest_addoption(parser):
         dest="dest_tf_plugin",
         default=".tfcache",
         help=(
-            "Use this directory for a terraform plugin cache "
-            "Default is to use .tfcache"
+            "[Depreceated] Use this directory for a terraform plugin cache "
+            "Default is to use .tfcache."
         ),
     )
 

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -44,7 +44,6 @@ def pytest_configure(config):
 
     tf.PytestConfig.value = config
     tf.LazyTFDebug.value = config.getoption("dest_tf_debug") or False
-    tf.TerraformRunner.debug = config.getoption("dest_tf_debug") or False
 
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(xdist.XDistTerraform(config))

--- a/pytest_terraform/plugin.py
+++ b/pytest_terraform/plugin.py
@@ -44,6 +44,8 @@ def pytest_configure(config):
         )
 
     tf.PytestConfig.value = config
+    tf.LazyTFDebug.value = config.getoption('dest_tf_debug') or False
+    tf.TerraformRunner.debug = config.getoption('dest_tf_debug') or False
 
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(xdist.XDistTerraform(config))
@@ -72,6 +74,12 @@ def pytest_addoption(parser):
         dest="dest_tf_replay",
         help=("Use recorded resources instead of invoking terraform"),
     )
+    group.addoption(
+        "--tf-debug",
+        action="store_true",
+        dest="dest_tf_debug",
+        help=("Debug terraform output and plugin output"),
+    )    
     group.addoption(
         "--tf-mod-dir",
         action="store",

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -42,8 +42,6 @@ class TerraformRunner(object):
         "approve": "-auto-approve",
     }
 
-    debug = False
-
     def __init__(
         self,
         work_dir,
@@ -370,10 +368,6 @@ class TerraformFixture(object):
         self.runner = None
         self.teardown_config = td.resolve(teardown)
         self.config = pytest_config
-
-    @property
-    def debug(self):
-        return LazyTFDebug.resolve(False)
 
     @property
     def name(self):

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -115,8 +115,8 @@ class TerraformRunner(object):
             tf_env["TF_DATA_DIR"] = self.work_dir
         cwd = self.module_dir or self.work_dir
         env.update(tf_env)
-        if self.debug:
-            print("run cmd", args, tf_env, cwd, file=sys.stderr)
+
+        write_log("run cmd", args, tf_env, cwd)
         run_cmd = subprocess.check_call
         if output:
             run_cmd = subprocess.check_output
@@ -343,6 +343,13 @@ PytestConfig = PlaceHolderValue("pytestconfig")
 LazyTFDebug = PlaceHolderValue("tf_debug")
 
 
+def write_log(msg, *parts):
+    if LazyTFDebug.resolve(False):
+        if parts:
+            msg = " ".join((msg, *(map(str, parts))))
+        print("%s\n" % msg, file=sys.stderr)
+
+
 class TerraformFixture(object):
     def __init__(
         self,
@@ -413,8 +420,7 @@ class TerraformFixture(object):
         return self.create(request, module_dir)
 
     def create(self, request, module_dir):
-        if LazyTFDebug.resolve():
-            print("tf create %s" % self.tf_root_module, file=sys.stderr)
+        write_log("tf create %s" % self.tf_root_module)
         self.runner.init()
         if self.teardown_config != td.OFF:
             request.addfinalizer(self.tear_down)
@@ -434,8 +440,7 @@ class TerraformFixture(object):
 
     def tear_down(self):
         # config behavor on runner
-        if LazyTFDebug.resolve():
-            print("tf teardown %s" % self.tf_root_module, file=sys.stderr)
+        write_log("tf teardown %s" % self.tf_root_module)
         try:
             self.runner.destroy()
         except subprocess.CalledProcessError as e:

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -28,7 +28,6 @@ from .options import teardown as td
 
 
 class TerraformRunner(object):
-
     command_templates = {
         "init": "init {input} {color} {plugin_dir}",
         "apply": "apply {input} {color} {state} {approve} {plan}",
@@ -54,7 +53,6 @@ class TerraformRunner(object):
         stream_output=None,
         tf_bin=None,
     ):
-
         self.work_dir = work_dir
         self.module_dir = module_dir
         # use parent dir of work/data dir to avoid

--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -108,7 +108,7 @@ class TerraformRunner(object):
     def _run_cmd(self, args, output=False):
         env = dict(os.environ)
         tf_env = {}
-        if LazyPluginCacheDir.resolve():
+        if LazyPluginCacheDir.resolve(False):
             tf_env["TF_PLUGIN_CACHE_DIR"] = LazyPluginCacheDir.resolve()
         tf_env["TF_IN_AUTOMATION"] = "yes"
         if self.module_dir:
@@ -393,7 +393,7 @@ class TerraformFixture(object):
         return TerraformRunner(
             str(work_dir),
             module_dir=module_dir,
-            plugin_cache=LazyPluginCacheDir.resolve(),
+            plugin_cache=LazyPluginCacheDir.resolve(False),
             tf_bin=LazyTfBin.resolve(),
         )
 

--- a/pytest_terraform/xdist.py
+++ b/pytest_terraform/xdist.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from pytest_terraform import tf
 from pytest_terraform.lock import lock_create, lock_delete

--- a/pytest_terraform/xdist.py
+++ b/pytest_terraform/xdist.py
@@ -67,7 +67,6 @@ class ScopedTerraformFixture(tf.TerraformFixture):
 
 
 class XDistTerraform(object):
-
     # Hooks
     # https://github.com/pytest-dev/pytest-xdist/blob/master/src/xdist/newhooks.py
 
@@ -115,7 +114,7 @@ class XDistTerraform(object):
         return fixture_map
 
     # worker hooks
-    def pytest_collection_modifyitems(self, session, config, items):
+    def pytest_collection_finish(self, session):
         """write out the collections of fixtures -> test ids
 
         in xdist this is only called from the workers
@@ -125,7 +124,7 @@ class XDistTerraform(object):
             for t in tf.terraform.get_fixtures()
             if isinstance(t, ScopedTerraformFixture)
         }
-        self.fixture_map = self.generate_fixture_map(items)
+        self.fixture_map = self.generate_fixture_map(session.items)
 
     def pytest_runtest_teardown(self, item, nextitem):
         found = []
@@ -178,7 +177,8 @@ class XDistTerraform(object):
             if self.completed.issuperset(self.fixture_map[f]):
                 if tf.LazyTFDebug.resolve(False):
                     print(
-                        "%s worker session down cleanup %s" % (self.wid, f), file=sys.stderr
+                        "%s worker session down cleanup %s" % (self.wid, f),
+                        file=sys.stderr,
                     )
                 tf.terraform.get_fixture(f).tear_down()
             else:

--- a/pytest_terraform/xdist.py
+++ b/pytest_terraform/xdist.py
@@ -34,10 +34,11 @@ class ScopedTerraformFixture(tf.TerraformFixture):
 
         with lock_create(self.state_dir / self.name) as (success, result):
             if success:
-                print(
-                    "%s create %s - success: %s" % (self.wid, self.name, success),
-                    file=sys.stderr,
-                )
+                if tf.LazyTFDebug.resolve(False):
+                    print(
+                        "%s create %s - success: %s" % (self.wid, self.name, success),
+                        file=sys.stderr,
+                    )
                 tf_test_api = super(ScopedTerraformFixture, self).create(
                     request, module_dir
                 )
@@ -55,10 +56,11 @@ class ScopedTerraformFixture(tf.TerraformFixture):
             if not success:
                 return
             work_dir = (self.state_dir / self.name).read_text("utf8")
-            print(
-                "%s teardown %s work-dir %s" % (self.wid, self.name, success),
-                file=sys.stderr,
-            )
+            if self.debug:
+                print(
+                    "%s teardown %s work-dir %s" % (self.wid, self.name, success),
+                    file=sys.stderr,
+                )
             super(ScopedTerraformFixture)
             runner = self.get_runner(self.resolve_module_dir(), work_dir)
             runner.destroy()
@@ -148,10 +150,11 @@ class XDistTerraform(object):
             # print('%s check result %s %s:%s' % (
             #       self.wid, completed, f, self.fixture_map[f]))
             if self.completed.issuperset(self.fixture_map[f]):
-                print(
-                    "%s execute test:%s teardown %s" % (self.wid, item.nodeid, f),
-                    file=sys.stderr,
-                )
+                if tf.LazyTFDebug.resolve(False):
+                    print(
+                        "%s execute test:%s teardown %s" % (self.wid, item.nodeid, f),
+                        file=sys.stderr,
+                    )
                 tf.terraform.get_fixture(f).tear_down()
                 self.fixture_map.pop(f)
 
@@ -173,13 +176,14 @@ class XDistTerraform(object):
             if f not in self.fixture_map:
                 continue
             if self.completed.issuperset(self.fixture_map[f]):
-                print(
-                    "%s worker session down cleanup %s" % (self.wid, f), file=sys.stderr
-                )
+                if tf.LazyTFDebug.resolve(False):
+                    print(
+                        "%s worker session down cleanup %s" % (self.wid, f), file=sys.stderr
+                    )
                 tf.terraform.get_fixture(f).tear_down()
             else:
                 remains.append(str((f, self.fixture_map[f].difference(self.completed))))
-        if remains:
+        if remains and tf.LazyTFDebug.resolve(False):
             print("%s tf remains %s" % (self.wid, remains), file=sys.stderr)
 
     # master hooks

--- a/tests/data/mrofarret/local_baz/tf_resources.json
+++ b/tests/data/mrofarret/local_baz/tf_resources.json
@@ -6,6 +6,12 @@
             "baz": {
                 "content": "baz!",
                 "content_base64": null,
+                "content_base64sha256": "GYygEuKSfhfg6WboOiMUAbr6WmzBaW3c/WCzdMKQ6Fw=",
+                "content_base64sha512": "+TyTAUP/jTLn89UpzicEjCK6AdmN4KBYd1WlDfKNwgAHrY9D6s+WqkuAb/ZoKd4TSDSNN+uFUt31+CFFjhCSdA==",
+                "content_md5": "4d36b5881759f7b1e3d65b5be9dc6790",
+                "content_sha1": "5fc5caaa8d04abb85be16b17953cd1a6e3ed549b",
+                "content_sha256": "198ca012e2927e17e0e966e83a231401bafa5a6cc1696ddcfd60b374c290e85c",
+                "content_sha512": "f93c930143ff8d32e7f3d529ce27048c22ba01d98de0a0587755a50df28dc20007ad8f43eacf96aa4b806ff66829de1348348d37eb8552ddf5f821458e109274",
                 "directory_permission": "0777",
                 "file_permission": "0777",
                 "filename": "./baz.txt",

--- a/tests/terraform/local_bar/.terraform.lock.hcl
+++ b/tests/terraform/local_bar/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.4.0"
+  hashes = [
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}

--- a/tests/terraform/local_bar/tf_resources.json
+++ b/tests/terraform/local_bar/tf_resources.json
@@ -6,6 +6,12 @@
             "bar": {
                 "content": "bar!",
                 "content_base64": null,
+                "content_base64sha256": "5oe3SfLNk2FZI6L3Bfqs5AM/NdV8z8plLNw5YWqUo8I=",
+                "content_base64sha512": "VsefHG45EmC85EGPSPpysV0kAveNz+q1rVoPqeeCbQQvU0uqL2FVcWPb8rOkDU9mk2y4Tj/XME5p+8h1nWC5+Q==",
+                "content_md5": "bb0d3e2eb8e78f4a10d55415e8e4677f",
+                "content_sha1": "3811e1a645e5371113584e6d18ff4843378ae590",
+                "content_sha256": "e687b749f2cd93615923a2f705faace4033f35d57ccfca652cdc39616a94a3c2",
+                "content_sha512": "56c79f1c6e391260bce4418f48fa72b15d2402f78dcfeab5ad5a0fa9e7826d042f534baa2f61557163dbf2b3a40d4f66936cb84e3fd7304e69fbc8759d60b9f9",
                 "directory_permission": "0777",
                 "file_permission": "0777",
                 "filename": "./bar.txt",

--- a/tests/terraform/local_buz/.terraform.lock.hcl
+++ b/tests/terraform/local_buz/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.4.0"
+  hashes = [
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}

--- a/tests/terraform/local_buz/tf_resources.json
+++ b/tests/terraform/local_buz/tf_resources.json
@@ -6,6 +6,12 @@
             "buz": {
                 "content": "fiz!",
                 "content_base64": null,
+                "content_base64sha256": "vikCmJzo1ZIiWEGfSvi3H0Oo2j+ng10mVvm7NrRW0lA=",
+                "content_base64sha512": "GxyZFjCjcNwXzgqwpesqGF9dHIdc4AxX+rFuTvktUHpPFLG8tXNV00zQuScillgb47xOlofyYlTX0FGZGE4rGQ==",
+                "content_md5": "b41ba5b9c442140644b7d2203ccb7da1",
+                "content_sha1": "1eb8252c1ec503dce3b41735251e12bdeadf1493",
+                "content_sha256": "be2902989ce8d5922258419f4af8b71f43a8da3fa7835d2656f9bb36b456d250",
+                "content_sha512": "1b1c991630a370dc17ce0ab0a5eb2a185f5d1c875ce00c57fab16e4ef92d507a4f14b1bcb57355d34cd0b9272296581be3bc4e9687f26254d7d05199184e2b19",
                 "directory_permission": "0777",
                 "file_permission": "0777",
                 "filename": "./buz.txt",

--- a/tests/terraform/local_foo/.terraform.lock.hcl
+++ b/tests/terraform/local_foo/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.4.0"
+  hashes = [
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}

--- a/tests/terraform/local_foo/tf_resources.json
+++ b/tests/terraform/local_foo/tf_resources.json
@@ -6,6 +6,12 @@
             "foo": {
                 "content": "foo!",
                 "content_base64": null,
+                "content_base64sha256": "wOCqrqBQvPO+JsDCPVj6iQwN+3nIojAWtKhs0oym6nE=",
+                "content_base64sha512": "TSCmPxazw2YStHurNILfRykjK/J4evgArH/2KnQuzQZodz4cq1f/ig2GeQO7mBI+Qx5jkTQEZxLCGs3mPtsB3Q==",
+                "content_md5": "35af8b7a9490467f75f19c1e5459f7e7",
+                "content_sha1": "4bf3e335199107182c6f7638efaad377acc7f452",
+                "content_sha256": "c0e0aaaea050bcf3be26c0c23d58fa890c0dfb79c8a23016b4a86cd28ca6ea71",
+                "content_sha512": "4d20a63f16b3c36612b47bab3482df4729232bf2787af800ac7ff62a742ecd0668773e1cab57ff8a0d867903bb98123e431e639134046712c21acde63edb01dd",
                 "directory_permission": "0777",
                 "file_permission": "0777",
                 "filename": "./foo.txt",

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -2,7 +2,6 @@ from pytest_terraform.lock import lock_create, lock_delete
 
 
 def test_lock_create(tmpdir):
-
     path = tmpdir / "foo"
 
     with lock_create(path) as (success, result):
@@ -18,7 +17,6 @@ def test_lock_create(tmpdir):
 
 
 def test_lock_create_ctx_fail(tmpdir):
-
     path = tmpdir / "foo2"
 
     try:

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -144,7 +144,6 @@ def test_tf_statejson_update_dict():
 
 
 def test_tf_statejson_update_bad():
-
     statejson = tf.TerraformStateJson("hello")
 
     with pytest.raises(ValueError):

--- a/tests/test_tf_fixture.py
+++ b/tests/test_tf_fixture.py
@@ -36,7 +36,7 @@ def test_tf_user_c(aws_sqs, aws_sns):
 
 
 def test_tf_user_many(aws_sqs, number_sequence):
-    return number_sequence
+    pass
 
 
 def test_tf_teardown_register():
@@ -84,7 +84,6 @@ def test_tf_teardown_exception():
 
 
 def test_tf_teardown_register_ignore():
-
     fixture = tf.TerraformFixture(
         tf_bin="fakebin",
         plugin_cache="fakecache",


### PR DESCRIPTION
closes #65
closes #62
closes #63 