### PR TITLE
feat: pass environment dict into TerraformRunner

### DIFF
--- a/pytest_terraform/tf.py
+++ b/pytest_terraform/tf.py
@@ -60,7 +60,9 @@ class TerraformRunner(object):
         self.stream_output = stream_output
         self.plugin_cache = plugin_cache or ""
         self.tf_bin = tf_bin
-        self.env = env
+        if env is not None:
+            assert isinstance(env, dict), "env must be a dict"
+        self.env = env or {}
 
     def apply(self, plan=True):
         """run terraform apply"""
@@ -115,12 +117,7 @@ class TerraformRunner(object):
             tf_env["TF_DATA_DIR"] = self.work_dir
         cwd = self.module_dir or self.work_dir
         env.update(tf_env)
-        if self.env is not None:
-            if isinstance(self.env, dict):
-                env.update(self.env)
-            else:
-                # Expected to be a callable that returns a dict.
-                env.update(self.env())
+        env.update(self.env)
 
         write_log("run cmd", args, tf_env, cwd)
         run_cmd = subprocess.check_call

--- a/tests/terraform/local_bar/.terraform.lock.hcl
+++ b/tests/terraform/local_bar/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
     "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",

--- a/tests/terraform/local_buz/.terraform.lock.hcl
+++ b/tests/terraform/local_buz/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
     "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",

--- a/tests/terraform/local_foo/.terraform.lock.hcl
+++ b/tests/terraform/local_foo/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
     "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -159,7 +159,16 @@ def tf_bin():
 def trunner(tmpdir, tf_bin):
     if not tf_bin:
         pytest.skip("Terraform binary missing")
-    yield tf.TerraformRunner(tmpdir.strpath, tf_bin=tf_bin)
+
+    # By default the TerraformRunner will set the state directory
+    # to be the parent of the work dir. Here we are using the tmpdir as the
+    # workdir, and we do not want to write outside our tmpdir, so set the state
+    # dir to be a subdirectory instead.
+    state_dir = Path(tmpdir) / "state"
+    state_dir.mkdir()
+    state_path = state_dir / "terraform.tfstate"
+
+    yield tf.TerraformRunner(tmpdir.strpath, tf_bin=tf_bin, state_path=str(state_path))
 
 
 @pytest.fixture

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -171,9 +171,8 @@ def tmpdir_writer(tmpdir):
     yield write_file
 
 
-@pytest.mark.skipif(not shutil.which("terraform"), reason="Terraform binary missing")
 @pytest.mark.parametrize("plan", (True, False))
-def test_tf_runner(testdir, tmpdir, plan):
+def test_tf_runner(trunner, tmpdir_writer, tmpdir, plan):
     # ** requires network access to install plugin **
     tmpdir_writer(
         """

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -247,24 +247,11 @@ output "foo" {
     assert state.outputs["foo"]["value"] == "bar"
 
 
-def test_tf_runner_env_callable(tmpdir_writer, trunner):
-    # ** requires network access to install plugin **
-    tmpdir_writer(
-        """
-variable "foo" {
-    type = string
-    default = ""
-}
+def test_tf_runner_env_wrong_type(tmpdir):
+    with pytest.raises(AssertionError) as err:
+        tf.TerraformRunner(tmpdir.strpath, env=1)
 
-output "foo" {
-    value = var.foo
-}
-"""
-    )
-    trunner.env = lambda: {"TF_VAR_foo": "bar"}
-    trunner.init()
-    state = trunner.apply()
-    assert state.outputs["foo"]["value"] == "bar"
+    assert "env must be a dict" == str(err.value)
 
 
 def xtest_bar_fixture(testdir):


### PR DESCRIPTION
We are already copying the environment when running terraform in a subprocess.
This patch allows additional environment variables to be provided as a dict that will just be set in the subprocess.